### PR TITLE
First pass at feedback from IETF-121

### DIFF
--- a/draft-ietf-masque-connect-ethernet.md
+++ b/draft-ietf-masque-connect-ethernet.md
@@ -468,6 +468,11 @@ and the Proxy is the same as in {{fig-full-tunnel}} above.
 
 # Performance Considerations
 
+When the protocol running inside the tunnel uses congestion control (e.g.,
+{{TCP}} or {{QUIC}}), the proxied traffic will incur at least two nested
+congestion controllers. Implementers will benefit from reading the guidance in
+{{Section 3.1.11 of ?UDP-USAGE=RFC8085}}.
+
 When the protocol running inside the tunnel uses loss recovery (e.g., {{TCP}} or
 {{QUIC}}) and the outer HTTP connection runs over TCP, the proxied traffic will
 incur at least two nested loss recovery mechanisms. This can reduce performance,

--- a/draft-ietf-masque-connect-ethernet.md
+++ b/draft-ietf-masque-connect-ethernet.md
@@ -373,7 +373,7 @@ and include, but are not limited to, the handling of broadcast packets and
 multicast groups, or the local termination of PAUSE frames.
 
 If an Ethernet proxying endpoint fails to deliver a frame to an underlying
-Ethernet segment, the endpoint SHOULD drop the frame.
+Ethernet segment, the endpoint MUST drop the frame.
 
 # Examples
 

--- a/draft-ietf-masque-connect-ethernet.md
+++ b/draft-ietf-masque-connect-ethernet.md
@@ -372,6 +372,9 @@ such as a kernel. Those responsibilities are beyond the scope of this document,
 and include, but are not limited to, the handling of broadcast packets and
 multicast groups, or the local termination of PAUSE frames.
 
+If an Ethernet proxying endpoint fails to deliver a frame to an underlying
+Ethernet segment, the endpoint SHOULD drop the frame.
+
 # Examples
 
 Ethernet proxying in HTTP enables the bridging of Ethernet broadcast domains.
@@ -464,14 +467,6 @@ what the Client is doing with the the tunnel; the exchange between the Client
 and the Proxy is the same as in {{fig-full-tunnel}} above.
 
 # Performance Considerations
-
-When the protocol running inside the tunnel uses congestion control (e.g.,
-{{TCP}} or {{QUIC}}), the proxied traffic will incur at least two nested
-congestion controllers. When tunneled packets are sent using QUIC DATAGRAM
-frames, the outer HTTP connection MAY disable congestion control for those
-packets that contain only QUIC DATAGRAM frames encapsulating Ethernet frames.
-Implementers will benefit from reading the guidance in {{Section 3.1.11 of
-?UDP-USAGE=RFC8085}}.
 
 When the protocol running inside the tunnel uses loss recovery (e.g., {{TCP}} or
 {{QUIC}}) and the outer HTTP connection runs over TCP, the proxied traffic will


### PR DESCRIPTION
This removes permission to drop QUIC's congestion control, and adds text about dropping Frames.

Should the `SHOULD drop` be a `MUST drop`?