### PR TITLE
VLANs: recommend using separate streams, not separate connections

### DIFF
--- a/draft-ietf-masque-connect-ethernet.md
+++ b/draft-ietf-masque-connect-ethernet.md
@@ -554,9 +554,9 @@ required, DATAGRAM capsules can be used.
 ## IEEE 802.1Q VLAN tagging {#vlan-recommendations}
 
 While the protocol as described can proxy Ethernet frames with IEEE 802.1Q VLAN
-tags, it is RECOMMENDED that individual VLANs be proxied in separate streams,
-and VLAN tags be stripped and applied by the Ethernet proxying endpoints as
-needed.
+tags, it is RECOMMENDED that individual VLANs be proxied in separate Ethernet
+proxying requests, and VLAN tags be stripped and applied by the Ethernet
+proxying endpoints as needed.
 
 # Security Considerations
 

--- a/draft-ietf-masque-connect-ethernet.md
+++ b/draft-ietf-masque-connect-ethernet.md
@@ -554,9 +554,9 @@ required, DATAGRAM capsules can be used.
 ## IEEE 802.1Q VLAN tagging {#vlan-recommendations}
 
 While the protocol as described can proxy Ethernet frames with IEEE 802.1Q VLAN
-tags, it is RECOMMENDED that individual VLANs be proxied in separate
-connections, and VLAN tags be stripped and applied by the Ethernet proxying
-endpoints as needed.
+tags, it is RECOMMENDED that individual VLANs be proxied in separate streams,
+and VLAN tags be stripped and applied by the Ethernet proxying endpoints as
+needed.
 
 # Security Considerations
 


### PR DESCRIPTION
Adjust VLAN suggestion to suggest separate streams rather than separate connections. It is already explicit that separate streams means separate connections for HTTP/1.1. For HTTP/2 and HTTP/3, I did not mean to suggest avoiding the multiplexing those protocols provide.